### PR TITLE
Update dependencies to their latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "io.github.marcinzh"
-ThisBuild / version := "0.6.0"
+ThisBuild / version := "0.7.0"
 ThisBuild / scalaVersion := "3.3.3"
 ThisBuild / crossScalaVersions := Seq(scalaVersion.value)
 
@@ -14,9 +14,9 @@ ThisBuild / scalacOptions ++= Seq(
 
 val Deps = {
   object deps {
-    val turbolift = "io.github.marcinzh" %% "turbolift-core" % "0.96.1"
-    val cats_core = "org.typelevel" %% "cats-core" % "2.12.0"
-    val cats_effect = "org.typelevel" %% "cats-effect" % "3.5.4"
+    val turbolift = "io.github.marcinzh" %% "turbolift-core" % "0.104.0"
+    val cats_core = "org.typelevel" %% "cats-core" % "2.13.0"
+    val cats_effect = "org.typelevel" %% "cats-effect" % "3.5.7"
   }
   deps
 }


### PR DESCRIPTION
## Background

Using Spot 0.6.0 with Turbolift 0.104.0 results in a `java.lang.NoClassDefFoundError: turbolift/ComputationCases$Map` exception at runtime.

This PR aims to solve this by bumping Spot's dependencies to their latest version:

- Bump `turbolift-core` to 0.104.0
- Bump `cats-core` to 2.13.0
- Bump `cats-effect` to 3.5.7

Additionally, it also bumps `spot` to 0.7.0.